### PR TITLE
Set Apache-2.0 license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "git+https://github.com/Kwiket/jets-seatmap-react-lib.git"
   },
   "author": "kwiket",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/Kwiket/jets-seatmap-react-lib/issues"
   },


### PR DESCRIPTION
The license string in package.json is set to MIT while the LICENSE file states it is Apache 2.0, I propose setting the appropriate SPDX value for Apache 2.0 in the license field since MIT and Apache 2.0 have different terms, rights, and obligations.