### PR TITLE
fixed blurred seatmap when scale is applied;

### DIFF
--- a/src/components/Seat/index.css
+++ b/src/components/Seat/index.css
@@ -122,6 +122,7 @@
   font-size: 30px;
   color: #fff;
   text-align: center;
+  z-index: 1;
 }
 
 .ST-5,

--- a/src/components/SeatMap/index.css
+++ b/src/components/SeatMap/index.css
@@ -8,3 +8,9 @@
   font-family: sans-serif;
   font-weight: normal;
 }
+
+.jets-seat-map * {
+  filter: blur(0);
+  -webkit-filter: blur(0);
+  -webkit-font-smoothing: subpixel-antialiased;
+}


### PR DESCRIPTION
Remove blurriness from SeatMap after scaling

- Remove the blurring effect affecting on the seat map elements
- Ensure compatibility with WebKit-based browsers when `sсale` is applied
- Enhance text rendering for better readability on WebKit browsers