### PR TITLE
Allow Authorization Scheme to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,8 +390,7 @@ Full config looks like this:
   apiUrl: 'PROVIDED_API_URL',               
   apiAppId: 'PROVIDED_APP_ID',
   apiKey: 'PROVIDED_API_KEY',
-  
-  authorizationScheme: 'Bearer',            // authorization scheme to be sent in API client requests 'Authorization' header (default: 'Bearer', e.g. 'Authorization: Bearer {apiKey}')
+  apiAuthorizationScheme: 'Bearer',            // authorization scheme to be sent in API client requests 'Authorization' header (default: 'Bearer', e.g. 'Authorization: Bearer {apiKey}')
   
   hiddenSeatFeatures: ['limitedRecline', 'getColdByExit', 'doNotRecline', 'wingInWindow', 'nearLavatory', 'nearGalley'], // to exclude some seat features from the built-in tooltip, all seat features are still available within the `onTooltipRequested` event
 

--- a/README.md
+++ b/README.md
@@ -391,6 +391,8 @@ Full config looks like this:
   apiAppId: 'PROVIDED_APP_ID',
   apiKey: 'PROVIDED_API_KEY',
   
+  authorizationScheme: 'Bearer',            // authorization scheme to be sent in API client requests 'Authorization' header (default: 'Bearer', e.g. 'Authorization: Bearer {apiKey}')
+  
   hiddenSeatFeatures: ['limitedRecline', 'getColdByExit', 'doNotRecline', 'wingInWindow', 'nearLavatory', 'nearGalley'], // to exclude some seat features from the built-in tooltip, all seat features are still available within the `onTooltipRequested` event
 
   colorTheme: {                             // most values are CSS-compatible

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jets-seatmap-react-lib",
-  "version": "3.0.49",
+  "version": "3.0.50",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jets-seatmap-react-lib",
-      "version": "3.0.49",
+      "version": "3.0.50",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.17.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seatmaps.com/react-lib",
-  "version": "3.0.49",
+  "version": "3.0.50",
   "description": "Jets seatmap react library.",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/common/api.js
+++ b/src/common/api.js
@@ -15,7 +15,7 @@ export class JetsApiService {
   getData = async (url, options = {}) => {
     let basicOptions = {};
     if (!options?.headers?.authorization) {
-      basicOptions = await this._getRequestOptions(this._authorizationScheme);
+      basicOptions = await this._getRequestOptions();
     }
 
     const reqOptions = { ...options, ...basicOptions };
@@ -29,7 +29,7 @@ export class JetsApiService {
   };
 
   postData = async (url, body, options = {}) => {
-    const basicOptions = await this._getRequestOptions(this._authorizationScheme);
+    const basicOptions = await this._getRequestOptions();
     const params = { ...options, method: 'post', body: JSON.stringify(body), ...basicOptions };
     const path = `${this._apiUrl}/${url}`;
     const response = await fetch(path, params);
@@ -42,20 +42,20 @@ export class JetsApiService {
     return responseData;
   };
 
-  _getRequestOptions = async (scheme) => {
+  _getRequestOptions = async () => {
     const token = await this._getToken();
     return {
       headers: {
         'content-type': 'application/json',
-        authorization: `${scheme} ${token}`,
+        authorization: `${this._authorizationScheme} ${token}`,
       },
     };
   };
 
-  _getAuthRequestOptions = (scheme, key) => {
+  _getAuthRequestOptions = key => {
     return {
       headers: {
-        authorization: `${scheme} ${key}`,
+        authorization: `${this._authorizationScheme} ${key}`,
       },
     };
   };
@@ -66,7 +66,7 @@ export class JetsApiService {
     if (token) return token;
 
     const path = `auth?appId=${this._appId}`;
-    const { accessToken } = await this.getData(path, this._getAuthRequestOptions(this._authorizationScheme, this._apiKey));
+    const { accessToken } = await this.getData(path, this._getAuthRequestOptions(this._apiKey));
 
     if (!accessToken) {
       throw new Error('Unable to authenticate');

--- a/src/common/api.js
+++ b/src/common/api.js
@@ -4,12 +4,12 @@ const JWT_TOKEN = 'jetsJwtToken';
 const TOKEN_EXPIRATION_BUFFER_IN_MS = 300000;
 
 export class JetsApiService {
-  constructor(appId, key, url, localStorage, authorizationScheme = DEFAULT_AUTHORIZATION_SCHEME) {
+  constructor(appId, key, url, localStorage, apiAuthorizationScheme = DEFAULT_AUTHORIZATION_SCHEME) {
     this._appId = appId;
     this._apiKey = key;
     this._apiUrl = url;
     this._localStorage = localStorage;
-    this._authorizationScheme = authorizationScheme;
+    this._apiAuthorizationScheme = apiAuthorizationScheme;
   }
 
   getData = async (url, options = {}) => {
@@ -47,7 +47,7 @@ export class JetsApiService {
     return {
       headers: {
         'content-type': 'application/json',
-        authorization: `${this._authorizationScheme} ${token}`,
+        authorization: `${this._apiAuthorizationScheme} ${token}`,
       },
     };
   };
@@ -55,7 +55,7 @@ export class JetsApiService {
   _getAuthRequestOptions = key => {
     return {
       headers: {
-        authorization: `${this._authorizationScheme} ${key}`,
+        authorization: `${this._apiAuthorizationScheme} ${key}`,
       },
     };
   };

--- a/src/common/api.js
+++ b/src/common/api.js
@@ -1,12 +1,15 @@
+import { DEFAULT_AUTHORIZATION_SCHEME } from './constants';
+
 const JWT_TOKEN = 'jetsJwtToken';
 const TOKEN_EXPIRATION_BUFFER_IN_MS = 300000;
 
 export class JetsApiService {
-  constructor(appId, key, url, localStorage) {
+  constructor(appId, key, url, localStorage, authorizationScheme = DEFAULT_AUTHORIZATION_SCHEME) {
     this._appId = appId;
     this._apiKey = key;
     this._apiUrl = url;
     this._localStorage = localStorage;
+    this._authorizationScheme = authorizationScheme;
   }
 
   getData = async (url, options = {}) => {

--- a/src/common/api.js
+++ b/src/common/api.js
@@ -15,7 +15,7 @@ export class JetsApiService {
   getData = async (url, options = {}) => {
     let basicOptions = {};
     if (!options?.headers?.authorization) {
-      basicOptions = await this._getRequestOptions();
+      basicOptions = await this._getRequestOptions(this._authorizationScheme);
     }
 
     const reqOptions = { ...options, ...basicOptions };
@@ -29,7 +29,7 @@ export class JetsApiService {
   };
 
   postData = async (url, body, options = {}) => {
-    const basicOptions = await this._getRequestOptions();
+    const basicOptions = await this._getRequestOptions(this._authorizationScheme);
     const params = { ...options, method: 'post', body: JSON.stringify(body), ...basicOptions };
     const path = `${this._apiUrl}/${url}`;
     const response = await fetch(path, params);
@@ -42,20 +42,20 @@ export class JetsApiService {
     return responseData;
   };
 
-  _getRequestOptions = async () => {
+  _getRequestOptions = async (scheme) => {
     const token = await this._getToken();
     return {
       headers: {
         'content-type': 'application/json',
-        authorization: `Bearer ${token}`,
+        authorization: `${scheme} ${token}`,
       },
     };
   };
 
-  _getAuthRequestOptions = key => {
+  _getAuthRequestOptions = (scheme, key) => {
     return {
       headers: {
-        authorization: `Bearer ${key}`,
+        authorization: `${scheme} ${key}`,
       },
     };
   };
@@ -66,7 +66,7 @@ export class JetsApiService {
     if (token) return token;
 
     const path = `auth?appId=${this._appId}`;
-    const { accessToken } = await this.getData(path, this._getAuthRequestOptions(this._apiKey));
+    const { accessToken } = await this.getData(path, this._getAuthRequestOptions(this._authorizationScheme, this._apiKey));
 
     if (!accessToken) {
       throw new Error('Unable to authenticate');

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -84,6 +84,8 @@ export const DEFAULT_UNITS = 'metric';
 
 export const DEFAULT_SCALE_TYPE = SCALE_TYPES.SCALE;
 
+export const DEFAULT_AUTHORIZATION_SCHEME = 'Bearer'
+
 export const DEFAULT_SEAT_MARGIN = 3;
 
 export const DEFAULT_SEAT_MAP_WIDTH = 350;

--- a/src/components/SeatMap/SeatMap.js
+++ b/src/components/SeatMap/SeatMap.js
@@ -475,7 +475,7 @@ JetsSeatMap.defaultProps = {
     units: DEFAULT_UNITS,
     scaleType: DEFAULT_SCALE_TYPE,
 
-    authorizationScheme: DEFAULT_AUTHORIZATION_SCHEME,
+    apiAuthorizationScheme: DEFAULT_AUTHORIZATION_SCHEME,
 
     hiddenSeatFeatures: [],
     colorTheme: {

--- a/src/components/SeatMap/SeatMap.js
+++ b/src/components/SeatMap/SeatMap.js
@@ -18,6 +18,7 @@ import {
   DEFAULT_RTL,
   DEFAULT_UNITS,
   DEFAULT_SCALE_TYPE,
+  DEFAULT_AUTHORIZATION_SCHEME,
   SCALE_TYPES,
   JetsContext,
   ENTITY_STATUS_MAP,
@@ -473,6 +474,9 @@ JetsSeatMap.defaultProps = {
     lang: DEFAULT_LANG,
     units: DEFAULT_UNITS,
     scaleType: DEFAULT_SCALE_TYPE,
+
+    authorizationScheme: DEFAULT_AUTHORIZATION_SCHEME,
+
     hiddenSeatFeatures: [],
     colorTheme: {
       seatMapBackgroundColor: THEME_BACKGROUND_COLOR,

--- a/src/components/SeatMap/api.js
+++ b/src/components/SeatMap/api.js
@@ -1,4 +1,4 @@
-import { DEFAULT_LANG, DEFAULT_UNITS, JetsApiService } from '../../common';
+import { DEFAULT_LANG, DEFAULT_UNITS, DEFAULT_AUTHORIZATION_SCHEME, JetsApiService } from '../../common';
 
 const API_SUPPORTED_LANGUAGES = [
   'AR',
@@ -32,8 +32,8 @@ const API_SUPPORTED_LANGUAGES = [
 ];
 
 export class JetsSeatMapApiService extends JetsApiService {
-  constructor(appId, key, url, localStorage = null) {
-    super(appId, key, url, localStorage);
+  constructor(appId, key, url, localStorage = null, authorizationScheme = DEFAULT_AUTHORIZATION_SCHEME) {
+    super(appId, key, url, localStorage, authorizationScheme);
   }
 
   getPlaneFeatures = async (flight, lang = DEFAULT_LANG, units = DEFAULT_UNITS) => {

--- a/src/components/SeatMap/api.js
+++ b/src/components/SeatMap/api.js
@@ -32,8 +32,8 @@ const API_SUPPORTED_LANGUAGES = [
 ];
 
 export class JetsSeatMapApiService extends JetsApiService {
-  constructor(appId, key, url, localStorage = null, authorizationScheme = DEFAULT_AUTHORIZATION_SCHEME) {
-    super(appId, key, url, localStorage, authorizationScheme);
+  constructor(appId, key, url, localStorage = null, apiAuthorizationScheme = DEFAULT_AUTHORIZATION_SCHEME) {
+    super(appId, key, url, localStorage, apiAuthorizationScheme);
   }
 
   getPlaneFeatures = async (flight, lang = DEFAULT_LANG, units = DEFAULT_UNITS) => {

--- a/src/components/SeatMap/service.js
+++ b/src/components/SeatMap/service.js
@@ -10,10 +10,10 @@ import { JetsDataHelper } from '../../common/data-helper';
 
 export class JetsSeatMapService {
   constructor(configuration) {
-    const { apiUrl, apiAppId, apiKey, colorTheme, authorizationScheme } = configuration;
+    const { apiUrl, apiAppId, apiKey, colorTheme, apiAuthorizationScheme } = configuration;
 
     const localStorage = new JetsLocalStorageService();
-    this._api = new JetsSeatMapApiService(apiAppId, apiKey, apiUrl, localStorage, authorizationScheme);
+    this._api = new JetsSeatMapApiService(apiAppId, apiKey, apiUrl, localStorage, apiAuthorizationScheme);
     this._preparer = new JetsContentPreparer();
     this._colorTheme = colorTheme;
     this._configuration = configuration;

--- a/src/components/SeatMap/service.js
+++ b/src/components/SeatMap/service.js
@@ -10,10 +10,10 @@ import { JetsDataHelper } from '../../common/data-helper';
 
 export class JetsSeatMapService {
   constructor(configuration) {
-    const { apiUrl, apiAppId, apiKey, colorTheme } = configuration;
+    const { apiUrl, apiAppId, apiKey, colorTheme, authorizationScheme } = configuration;
 
     const localStorage = new JetsLocalStorageService();
-    this._api = new JetsSeatMapApiService(apiAppId, apiKey, apiUrl, localStorage);
+    this._api = new JetsSeatMapApiService(apiAppId, apiKey, apiUrl, localStorage, authorizationScheme);
     this._preparer = new JetsContentPreparer();
     this._colorTheme = colorTheme;
     this._configuration = configuration;


### PR DESCRIPTION
This PR adds the ability for the authorization scheme to be configured. This is the "Bearer" in "Authorization: Bearer {token}"

See: `<auth-scheme>` in https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization#syntax

The default authorization scheme is "Bearer" to maintain existing usages of the code.