### PR TITLE
Tests for JetsSeatMapApiService

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seatmaps.com/react-lib",
-  "version": "3.0.53",
+  "version": "3.0.54",
   "description": "Jets seatmap react library.",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,7 +32,7 @@ export default [
         targets: [{ src: 'src/assets/img', dest: 'dist/assets' }],
       }),
       babel({
-        exclude: ['node_modules/**', '**/*.test.js', 'jest.config.js', 'jest-config/**', 'scripts/**', '__mocks__/**'],
+        exclude: ['node_modules/**', '**/*.test.js', 'jest.config.js', 'jest-config/**', 'scripts/**', '__mocks__/**', '**/__fixtures__/**'],
         presets: ['@babel/preset-react'],
         plugins: [
           [

--- a/src/components/SeatMap/__fixtures__/seatMapApiGetPlaneFeatures.js
+++ b/src/components/SeatMap/__fixtures__/seatMapApiGetPlaneFeatures.js
@@ -1,0 +1,11 @@
+export const flightDetails = (overrides = {}) => ({
+  id: '1111',
+  airlineCode: 'EK',
+  flightNo: '2',
+  departureDate: '2025-07-19',
+  departure: 'LHR',
+  arrival: 'DXB',
+  cabinClass: 'A',
+  passengerType: 'ADT',
+  ...overrides,
+});

--- a/src/components/SeatMap/__fixtures__/seatMapApiPostDataResponse.js
+++ b/src/components/SeatMap/__fixtures__/seatMapApiPostDataResponse.js
@@ -1,0 +1,125 @@
+const seatFeatures = (overrides = {}) => ({
+  extraLegroom: '+',
+  noFloorStorage: '-',
+  nearLavatory: '-',
+  nearStairs: '-',
+  exitRow: '+',
+  ...overrides,
+});
+
+const seat = (overrides = {}) => ({
+  color: '#5AB54C',
+  features: seatFeatures(),
+  leftOffset: 0,
+  letter: 'A',
+  topOffset: 0,
+  ...overrides,
+});
+
+const row = (overrides = {}) => ({
+  classCode: 'P',
+  number: 33,
+  seats: [seat()],
+  seatScheme: 'SS-EEEE-SS',
+  seatType: 14,
+  topOffset: 0,
+  name: 'Premium Economy',
+  ...overrides,
+});
+
+const wingsInfo = (overrides = {}) => ({
+  deckLevel: 1,
+  topOffset: 2600,
+  height: 3700,
+  ...overrides,
+});
+
+const exit = (overrides = {}) => ({
+  type: 'right',
+  topOffset: -314,
+  ...overrides,
+});
+
+const bulk = (overrides = {}) => ({
+  id: '16',
+  type: 'left',
+  iconType: '',
+  topOffset: 1560,
+  xOffset: 0,
+  width: 382,
+  height: 176,
+  align: 'left',
+  ...overrides,
+});
+
+const deck = (overrides = {}) => ({
+  bulks: [bulk()],
+  level: 1,
+  rows: [row()],
+  exits: [exit()],
+  wingsInfo: wingsInfo(),
+  ...overrides,
+});
+
+export const plane = (overrides = {}) => ({
+  id: 'dc1913d422398c25c5f0b81cab94cc87',
+  brand: 'Airbus',
+  model: '388',
+  summary: 'Airbus A380-800',
+  name: 'Airbus A388',
+  windowSize: 'large',
+  isWideBody: true,
+  seatmapExists: true,
+  ...overrides,
+});
+
+export const cabin = (overrides = {}) => ({
+  pitch: '218 cm',
+  recline: '180°',
+  width: '58 cm',
+  flatness: 'full_flat_seat',
+  legroomSummary: '218 cm legroom',
+  reclineSummary: 'full flat seat',
+  type: 'standard_legroom',
+  ...overrides,
+});
+
+export const entertainment = (overrides = {}) => ({
+  exists: true,
+  cost: 'free',
+  deliveryType: 'in-seat',
+  summary: 'free on demand entertainment',
+  ...overrides,
+});
+
+export const wifi = (overrides = {}) => ({
+  exists: true,
+  cost: 'free',
+  summary: 'WiFi enabled',
+  ...overrides,
+});
+
+export const power = (overrides = {}) => ({
+  summary: 'power available: AC/USB',
+  exists: true,
+  type: 'AC/USB',
+  usbPort: true,
+  powerOutlet: true,
+  ...overrides,
+});
+
+export const seatDetails = (overrides = {}) => ({
+  decks: [deck()],
+  ...overrides,
+});
+
+export const cabinItem = (overrides = {}) => ({
+  id: '1111',
+  cabin: cabin(),
+  entertainment: entertainment(),
+  power: power(),
+  wifi: wifi(),
+  plane: plane(),
+  error: null,
+  ...overrides,
+});

--- a/src/components/SeatMap/api.js
+++ b/src/components/SeatMap/api.js
@@ -57,7 +57,7 @@ export class JetsSeatMapApiService extends JetsApiService {
           if (item && item.error) {
             throw new Error(item.error);
           }
-          if (flight.cabinClass) {
+          if (flight.cabinClass && cabinClasses.includes(flight.cabinClass)) {
             const { id, cabin, entertainment, power, wifi } = item;
             result[flight.cabinClass] = {
               cabin,

--- a/src/components/SeatMap/api.test.js
+++ b/src/components/SeatMap/api.test.js
@@ -1,0 +1,210 @@
+import { JetsSeatMapApiService } from './api';
+import {
+  cabin,
+  entertainment,
+  power,
+  wifi,
+  seatDetails,
+  cabinItem,
+} from './__fixtures__/seatMapApiPostDataResponse';
+import { flightDetails } from './__fixtures__/seatMapApiGetPlaneFeatures';
+
+jest.mock('./api', () => {
+  const module = jest.requireActual('./api');
+  return {
+    ...module,
+    JetsSeatMapApiService: class extends module.JetsSeatMapApiService {
+      postData = jest.fn();
+    },
+  };
+});
+
+const api = new JetsSeatMapApiService('appId', 'key', 'url');
+
+describe('JetsSeatMapApiService', () => {
+  describe('when the getPlaneFeatures function is called', () => {
+    beforeEach(() => {
+      const singleCabinResponseFixture = [{
+        id: '1111',
+        cabin: cabin(),
+        entertainment: entertainment(),
+        power: power(),
+        wifi: wifi(),
+        seatDetails: seatDetails(),
+      }];
+      api.postData.mockImplementation(() => singleCabinResponseFixture);
+    });
+
+    it('should call postData with the correct parameters', async () => {
+      const flightFixture = flightDetails();
+
+      await api.getPlaneFeatures(flightFixture, 'EN', 'metric');
+
+      expect(api.postData).toHaveBeenCalledWith(
+        'flight/features/plane/seatmap',
+        { flight: flightFixture, lang: 'EN', units: 'metric' },
+      );
+    });
+
+    it('should call postData with the default language if the provided language is not supported', async () => {
+      const flightFixture = flightDetails();
+
+      await api.getPlaneFeatures(flightFixture, 'A', 'metric');
+
+      expect(api.postData).toHaveBeenCalledWith(
+        'flight/features/plane/seatmap',
+        { flight: flightFixture, lang: 'EN', units: 'metric' },
+      );
+    });
+  });
+
+  describe('when a specific cabin class (F, B, P or E) is provided', () => {
+    it('should return the correct information when all the information is present', async () => {
+      const flightFixture = flightDetails({ cabinClass: 'E' });
+      const singleCabinResponseFixture = [{
+        id: '1111',
+        cabin: cabin(),
+        entertainment: entertainment(),
+        power: power(),
+        wifi: wifi(),
+        seatDetails: seatDetails(),
+      }];
+      api.postData.mockImplementation(() => singleCabinResponseFixture);
+
+      const result = await api.getPlaneFeatures(flightFixture);
+
+      expect(result).toEqual({
+        E: {
+          cabin: singleCabinResponseFixture[0].cabin,
+          entertainment: singleCabinResponseFixture[0].entertainment,
+          power: singleCabinResponseFixture[0].power,
+          wifi: singleCabinResponseFixture[0].wifi,
+        },
+        seatDetails: singleCabinResponseFixture[0].seatDetails,
+      });
+    });
+
+    it('should throw if no seat details were returned from the API', async () => {
+      const flightFixture = flightDetails({ cabinClass: 'E' });
+      const singleCabinResponseFixture = [{
+        id: '1111',
+        cabin: cabin(),
+        entertainment: entertainment(),
+        power: power(),
+        wifi: wifi(),
+      }];
+      api.postData.mockImplementation(() => singleCabinResponseFixture);
+
+      await expect(api.getPlaneFeatures(flightFixture)).rejects.toThrow('data is not found for the flight: 1111');
+    });
+
+    it('should throw if the response item has an error', async () => {
+      const flightFixture = flightDetails({ cabinClass: 'E' });
+      const singleCabinResponseFixture = [{
+        id: '1111',
+        cabin: cabin(),
+        entertainment: entertainment(),
+        power: power(),
+        wifi: wifi(),
+        error: 'Something went wrong!',
+      }];
+      api.postData.mockImplementation(() => singleCabinResponseFixture);
+
+      await expect(api.getPlaneFeatures(flightFixture)).rejects.toThrow('Something went wrong!');
+    });
+  });
+
+  describe('when the whole plane (cabin class A) is provided', () => {
+    it('should return the correct information when all the information is present', async () => {
+      const flightFixture = flightDetails({ cabinClass: 'A' });
+      const allCabinsResponseFixture = [
+        {
+          id: '1111',
+          seatDetails: seatDetails(),
+        },
+        cabinItem({ id: '1111:F' }),
+        cabinItem({ id: '1111:B' }),
+        cabinItem({ id: '1111:P' }),
+        cabinItem({ id: '1111:E' }),
+      ];
+      api.postData.mockImplementation(() => allCabinsResponseFixture);
+
+      const result = await api.getPlaneFeatures(flightFixture);
+
+      expect(result).toEqual({
+        seatDetails: allCabinsResponseFixture[0].seatDetails,
+        F: {
+          cabin: allCabinsResponseFixture[1].cabin,
+          entertainment: allCabinsResponseFixture[1].entertainment,
+          power: allCabinsResponseFixture[1].power,
+          wifi: allCabinsResponseFixture[1].wifi,
+        },
+        B: {
+          cabin: allCabinsResponseFixture[2].cabin,
+          entertainment: allCabinsResponseFixture[2].entertainment,
+          power: allCabinsResponseFixture[2].power,
+          wifi: allCabinsResponseFixture[2].wifi,
+        },
+        P: {
+          cabin: allCabinsResponseFixture[3].cabin,
+          entertainment: allCabinsResponseFixture[3].entertainment,
+          power: allCabinsResponseFixture[3].power,
+          wifi: allCabinsResponseFixture[3].wifi,
+        },
+        E: {
+          cabin: allCabinsResponseFixture[4].cabin,
+          entertainment: allCabinsResponseFixture[4].entertainment,
+          power: allCabinsResponseFixture[4].power,
+          wifi: allCabinsResponseFixture[4].wifi,
+        },
+      });
+    });
+
+    it('should throw if no seat details were returned from the API', async () => {
+      const flightFixture = flightDetails({ cabinClass: 'A' });
+      const allCabinsResponseFixture = [
+        cabinItem({ id: '1111:F' }),
+        cabinItem({ id: '1111:B' }),
+        cabinItem({ id: '1111:P' }),
+        cabinItem({ id: '1111:E' }),
+      ];
+      api.postData.mockImplementation(() => allCabinsResponseFixture);
+
+      await expect(api.getPlaneFeatures(flightFixture)).rejects.toThrow('data is not found for the flight: 1111');
+    });
+
+    it('should throw if the seat details response item has an error', async () => {
+      const flightFixture = flightDetails({ cabinClass: 'E' });
+      const allCabinsResponseFixture = [
+        {
+          id: '1111',
+          seatDetails: seatDetails(),
+          error: 'Something went wrong!',
+        },
+        cabinItem({ id: '1111:F' }),
+        cabinItem({ id: '1111:B' }),
+        cabinItem({ id: '1111:P' }),
+        cabinItem({ id: '1111:E' }),
+      ];
+      api.postData.mockImplementation(() => allCabinsResponseFixture);
+
+      await expect(api.getPlaneFeatures(flightFixture)).rejects.toThrow('Something went wrong!');
+    });
+  });
+
+  describe('when a cabin class is provided that is not supported', () => {
+    it('should return...', async () => {
+      const flightFixture = flightDetails({ cabinClass: 'Q' });
+      const errorResponse = {
+        'statusCode': 400,
+        'message': 'cabinClass must be one of the following values: A, F, B, P, E',
+        'error': 'Bad Request',
+      };
+      api.postData.mockImplementation(() => errorResponse);
+
+      await expect(api.getPlaneFeatures(flightFixture)).rejects.toThrow();
+    });
+  });
+});
+
+


### PR DESCRIPTION
 - Adding in the first tests for the JetsSeatMapApiService.

TravelPerk [JIRA](https://travelperk.atlassian.net/browse/APP-95577). 

Lorena and I discussed keeping the fixtures under a `__fixtures__` folder close to the area tested. Up for debate! You can see the schema of the API response [here](https://sandbox.quicket.io/doc/#/flight/plane-seatmap).