### PR TITLE
fix deck title scaling on zoom in Safari;

### DIFF
--- a/src/components/DeckTitle/DeckTitle.js
+++ b/src/components/DeckTitle/DeckTitle.js
@@ -1,14 +1,20 @@
 import React, { useContext, useRef } from 'react';
-import { JetsContext, LOCALES_MAP, DEFAULT_DECK_TITLE_HEIGHT } from '../../common';
+import { JetsContext, LOCALES_MAP, DEFAULT_DECK_TITLE_HEIGHT, SCALE_TYPES } from '../../common';
+import { useEnvironmentInfo } from '../../common/hooks/useEnvironmentInfo';
 
 import './DeckTitle.css';
 
 export const JetsDeckTitle = ({ number, lang, localeKey }) => {
-  const { params, colorTheme } = useContext(JetsContext);
+  const { config, params, colorTheme } = useContext(JetsContext);
   const elementRef = useRef(null);
 
+  const { isSafari } = useEnvironmentInfo();
+
+  const shouldAdjustScaling = isSafari && config?.scaleType === SCALE_TYPES.ZOOM;
+
   const style = {
-    transform: `scale(${params.antiScale}) translateY(30px)`,
+    transform: shouldAdjustScaling ? undefined : `scale(${params.antiScale}) translateY(30px)`,
+    zoom: shouldAdjustScaling ? params.antiScale : undefined,
     height: `${DEFAULT_DECK_TITLE_HEIGHT}px`,
     color: colorTheme.deckLabelTitleColor,
   };

--- a/src/components/DeckTitle/DeckTitle.test.js
+++ b/src/components/DeckTitle/DeckTitle.test.js
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import { MockJetsContextProvider } from '../../__mocks__/MockJetsContext';
 
@@ -6,17 +6,77 @@ import { DECK_LOCALE_KEY } from '../Deck';
 import { JetsDeckTitle } from './index';
 import CONFIG_MOCK from '../Demo/constants/config-mock';
 
-const setup = ({ lang = CONFIG_MOCK.lang, localeKey = DECK_LOCALE_KEY, ...rest }) => {
-  render(
-    <MockJetsContextProvider>
+import { SCALE_TYPES } from '../../common';
+
+import { useEnvironmentInfo } from '../../common/hooks/useEnvironmentInfo';
+
+jest.mock('../../common/hooks/useEnvironmentInfo', () => ({
+  useEnvironmentInfo: jest.fn(),
+}));
+
+const mockAntiScale = 2;
+const deckTitleSelector = '.jets-deck--title';
+
+const defaultContextProps = {
+  config: { scaleType: SCALE_TYPES.ZOOM },
+  params: { antiScale: mockAntiScale },
+};
+
+const setup = ({
+  lang = CONFIG_MOCK.lang,
+  localeKey = DECK_LOCALE_KEY,
+  contextProps = defaultContextProps,
+  ...rest
+} = {}) => {
+  return render(
+    <MockJetsContextProvider {...contextProps}>
       <JetsDeckTitle {...rest} lang={lang} localeKey={localeKey} />
     </MockJetsContextProvider>
   );
 };
 
 describe('JetsDeckTitle', () => {
+  beforeEach(() => {
+    useEnvironmentInfo.mockReturnValue({ isSafari: false });
+  });
+
   it('should render the Deck number correctly (EN)', () => {
     setup({ number: '2' });
     expect(screen.getByText('Deck: 2')).toBeInTheDocument();
+  });
+
+  it('should not adjust scaling if it is not Safari browser', () => {
+    const { container } = setup();
+
+    const titleEl = container.querySelector(deckTitleSelector);
+
+    expect(titleEl).toBeInTheDocument();
+    expect(titleEl).toHaveStyle(`transform: scale(${mockAntiScale}) translateY(30px)`);
+    expect(titleEl).not.toHaveStyle(`zoom: ${mockAntiScale}`);
+  });
+
+  it('should adjusts scaling if it is Safari and scaleType is zoom', () => {
+    useEnvironmentInfo.mockReturnValue({ isSafari: true });
+
+    const { container } = setup();
+
+    const titleEl = container.querySelector(deckTitleSelector);
+
+    expect(titleEl).toBeInTheDocument();
+    expect(titleEl).not.toHaveStyle(`transform: scale(${mockAntiScale}) translateY(30px)`);
+  });
+
+  it('should not adjust scaling if Safari but scaleType is not zoom', () => {
+    useEnvironmentInfo.mockReturnValue({ isSafari: true });
+
+    const { container } = setup({
+      contextProps: { ...defaultContextProps, config: { scaleType: SCALE_TYPES.SCALE } },
+    });
+
+    const titleEl = container.querySelector(deckTitleSelector);
+
+    expect(titleEl).toBeInTheDocument();
+    expect(titleEl).toHaveStyle(`transform: scale(${mockAntiScale}) translateY(30px)`);
+    expect(titleEl).not.toHaveStyle(`zoom: ${mockAntiScale}`);
   });
 });


### PR DESCRIPTION
Minor adjustments to `DeckTitle` scaling to fix the size and alignment when `scaleType: zoom` in Safari