### PR TITLE
Return plane in onSeatMapInited callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,18 @@ interface IMediaData {
   panoData: IPanoData[];
 }
 
+interface IPlaneData {
+  id: string;
+  brand: string;
+  model: string;
+  summary: string;
+  name: string;
+  windowSize: string;
+  isWideBody: boolean;
+  seatmapExists: string;
+  noseType: string;
+}
+
 interface IPhotoData {
   file: string;
   thumb: string;
@@ -578,6 +590,7 @@ interface IInitialLayoutData {
   scaleFactor: number;          // scale applied to fit into provided boundaries
   widthInPx: number;            // outer width of the plane. CAUTION: if "horizontal" flag is set - height and width are swapped around to reflect that
   media: IMediaData;            // contains media data for the aircraft cabin
+  plane: IPlaneData;            // contains plane data for the aircraft cabin
   error: string;                // error message if not possible to build a seat map
 }
 ```

--- a/src/components/SeatMap/SeatMap.js
+++ b/src/components/SeatMap/SeatMap.js
@@ -277,6 +277,7 @@ export const JetsSeatMap = ({
             currentDeckIndex: activeDeck,
             availabilityData: data?.availabilityData,
             media: data?.media,
+            plane: data?.plane,
           });
           hasReceivedFirstParams.current = false;
         }

--- a/src/components/SeatMap/service.js
+++ b/src/components/SeatMap/service.js
@@ -38,6 +38,7 @@ export class JetsSeatMapService {
       bulks,
       availabilityData: planeFeatures?.availabilityData,
       media: planeFeatures?.media,
+      plane: planeFeatures?.plane,
     };
   };
 


### PR DESCRIPTION
This PR makes it so we return the `plane` from the Quicket API response as part of the onSeatMapInited callback. This will help callers be able to consume information about the plane (e.g. model, name, id).